### PR TITLE
feat(Config page): :sparkles: Remember "token" with browser

### DIFF
--- a/src/views/Config/index.vue
+++ b/src/views/Config/index.vue
@@ -3,11 +3,22 @@
     <!-- Token -->
     <el-form label-width="70px" label-position="right" class="config-form">
       <el-form-item label="Token">
-        <el-input v-model="userConfigInfo.token" :clearable="true"></el-input>
+        <el-input
+          v-model="userConfigInfo.token"
+          clearable
+          show-password
+          autofocus
+        ></el-input>
       </el-form-item>
 
       <el-form-item class="operation">
-        <el-button plain size="small" type="primary" @click="getUserInfo()">
+        <el-button
+          plain
+          size="small"
+          type="primary"
+          native-type="submit"
+          @click="getUserInfo()"
+        >
           确认 Token
         </el-button>
       </el-form-item>


### PR DESCRIPTION
借用浏览器原生记住密码功能，降低更换设备、清楚缓存（浏览器数据）、更换浏览器后的重新配置的成本，从而避免多次生成 `Token`。
浏览器开启同步后还可以同步 `Token`，更巴适了