### PR TITLE
添加图床管理页列表样式

### DIFF
--- a/src/components/image-card.vue
+++ b/src/components/image-card.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="image-card"
+    :class="{ listing: listing }"
     v-loading="imageObj.deleting"
     element-loading-text="删除中..."
     element-loading-background="rgba(0, 0, 0, 0.6)"
@@ -44,6 +45,10 @@ export default defineComponent({
   },
 
   props: {
+    listing: {
+      type: Boolean,
+      default: false
+    },
     imageObj: {
       type: Object,
       default: () => {}
@@ -112,8 +117,7 @@ export default defineComponent({
 </script>
 
 <style scoped lang="stylus">
-
-@import "../style.styl";
+@import '../style.styl';
 
 $infoBoxHeight = 56px;
 
@@ -136,9 +140,7 @@ $infoBoxHeight = 56px;
       height: 100%;
       object-fit: cover;
     }
-
   }
-
 
   .info-box {
     width: 100%;
@@ -179,12 +181,43 @@ $infoBoxHeight = 56px;
           i {
             font-size: 16px;
           }
-
         }
-
       }
     }
   }
 
+  &.listing {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    padding: 5px;
+    padding-bottom: 5px;
+    border-radius: $box-border-radius;
+
+    .image-box {
+      height: 45px;
+      width: 45px;
+    }
+
+    .info-box {
+      position: relative;
+      width: 80%;
+    }
+
+    :deep(.el-loading-mask) {
+      .el-loading-spinner {
+        margin-top: -25px;
+
+        .circular {
+          height: 24px;
+          width: 24px;
+        }
+
+        .el-loading-text {
+          margin: 0;
+        }
+      }
+    }
+  }
 }
 </style>

--- a/src/style.styl
+++ b/src/style.styl
@@ -52,6 +52,12 @@ li {
   align-items center
 }
 
+.flex-start {
+  display flex
+  justify-content flex-start
+  align-items center
+}
+
 .page-container {
   width 100%
   height 100%

--- a/src/views/Management/index.styl
+++ b/src/views/Management/index.styl
@@ -23,6 +23,13 @@ $infoBarHeight = 50px;
       justify-content: space-between;
       font-size: 14px;
       padding-bottom: 20px;
+      .right {
+        .el-icon-tickets,
+        .el-icon-menu {
+          font-size 24px;
+          margin-right 10px;
+        }
+      }
     }
 
     .bottom {
@@ -47,6 +54,13 @@ $infoBarHeight = 50px;
 
           &:last-child {
             margin-right: 0;
+          }
+        }
+        &.listing {
+          li.image-item {
+            min-width 222px;
+            padding 0px;
+            margin 10px 5px;
           }
         }
       }

--- a/src/views/Management/index.vue
+++ b/src/views/Management/index.vue
@@ -6,7 +6,10 @@
           <selectedInfoBar></selectedInfoBar>
         </div>
 
-        <div class="right">
+        <div class="right flex-start">
+          展示类型：
+          <i v-if="listing" class="el-icon-tickets" @click.stop="toggleListing"></i>
+          <i v-else class="el-icon-menu" @click.stop="toggleListing"></i>
           切换目录：
           <el-select
             v-model="userConfigInfo.selectedDir"
@@ -31,17 +34,17 @@
         element-loading-text="加载中..."
         element-loading-background="rgba(0, 0, 0, 0.6)"
       >
-        <ul class="image-list">
+        <ul class="image-list" :class="{ listing: listing === true }">
           <li
             class="image-item"
             v-for="(image, index) in currentDirImageList"
             :key="index"
             :style="{
-              width: '220px',
-              height: '230px'
+              width: listing ? '32%' : '220px',
+              height: listing ? '60px' : '230px'
             }"
           >
-            <ImageCard :image-obj="image" />
+            <ImageCard :image-obj="image" :listing="listing" />
           </li>
         </ul>
       </div>
@@ -83,6 +86,7 @@ export default defineComponent({
 
       currentDirImageList: [],
       loadingImageList: false,
+      listing: false,
 
       initDirImageList() {
         if (!this.dirImageList.length) {
@@ -219,11 +223,19 @@ export default defineComponent({
           return
         }
         this.currentDirImageList = targetDirObj.imageList
+      },
+
+      toggleListing() {
+        this.listing = !this.listing
       }
     })
 
     function dirChange(dir: string) {
       reactiveData.dirChange(dir)
+    }
+
+    function toggleListing() {
+      reactiveData.toggleListing()
     }
 
     onMounted(() => {
@@ -253,12 +265,13 @@ export default defineComponent({
 
     return {
       ...toRefs(reactiveData),
-      dirChange
+      dirChange,
+      toggleListing
     }
   }
 })
 </script>
 
 <style scoped lang="stylus">
-@import "index.styl"
+@import 'index.styl';
 </style>


### PR DESCRIPTION
初始还是原来的样式，点击按钮替换成列表：
![image](https://user-images.githubusercontent.com/40223254/118845346-485a1800-b8fe-11eb-9176-c95d6ca12cb1.png)
列表模式下删除图片时的样式（例子）：
![image](https://user-images.githubusercontent.com/40223254/118845443-5b6ce800-b8fe-11eb-99ea-cc57ae6cbede.png)
