### PR TITLE
fix(management): folder list and picture list on the same line

### DIFF
--- a/src/style/base.styl
+++ b/src/style/base.styl
@@ -90,6 +90,7 @@ ul, ol, li {
     display block
     clear both
     visibility hidden
+    overflow hidden
     height 0
   }
 }


### PR DESCRIPTION
#118 
修复 Chrome (版本 98.0.4758.102) 浏览器下图床管理页面刷新图片列表后的显示问题