### PR TITLE
fix: fix issue114

### DIFF
--- a/src/views/config/config.vue
+++ b/src/views/config/config.vue
@@ -240,7 +240,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue'
+import { onMounted, computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { useStore } from '@/store'
@@ -508,6 +508,12 @@ watch(
     }
   }
 )
+
+onMounted(() => {
+  if (userConfigInfo.dirMode === DirModeEnum.autoDir) {
+    userConfigInfo.selectedDir = TimeHelper.getYyyyMmDd()
+  }
+})
 </script>
 
 <style scoped lang="stylus">


### PR DESCRIPTION
 fix issue114 -> config page mounted regain selectedDir when choose autoDir

userConfigInfo data is come from computed, so i try to regain the selectedDir to fix issue #114 . Because computed will call between hooks "beforeMount" and "mounted"。