### PR TITLE
原有Jsdelivr CDN可能暂时被墙,现替换为Staticaly CDN 正常提供CDN外链服务

### DIFF
--- a/src/common/utils/generate-external-link.ts
+++ b/src/common/utils/generate-external-link.ts
@@ -8,7 +8,7 @@ const generateExternalLink = (
   config: UserConfigInfoModel
   // eslint-disable-next-line consistent-return
 ): string => {
-  const cdnLink: string = `https://cdn.jsdelivr.net/gh/${config.owner}/${config.selectedRepos}@${config.selectedBranch}/${content.path}`
+  const cdnLink: string = `https://cdn.staticaly.com/gh/${config.owner}/${config.selectedRepos}@${config.selectedBranch}/${content.path}`
   const ghLink: string = decodeURI(content.download_url)
 
   // eslint-disable-next-line default-case


### PR DESCRIPTION
Replace the CDN acceleration service with a Staticaly CDN