### PR TITLE
fix: the name field of some users is empty

### DIFF
--- a/src/components/header-content/header-content.vue
+++ b/src/components/header-content/header-content.vue
@@ -78,7 +78,11 @@
               </el-select>
             </li>
             <el-divider style="margin: 5px 0" />
-            <li class="content-item" v-if="userConfigInfo.name" @click="logout">
+            <li
+              class="content-item"
+              v-if="userConfigInfo.name || userConfigInfo.owner"
+              @click="logout"
+            >
               {{ $t('header.logout') }}
             </li>
             <li class="content-item" v-else @click="router.push('/config')">


### PR DESCRIPTION
我的用户名是null，所以通过name字段来判断会导致我无法显示退出登录按钮，可以使用别的字段来判断比如userConfigInfo.owner