### PR TITLE
chore:  correct pnpm version and fixed it

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "picx",
   "version": "3.0.0",
   "private": false,
+  "packageManager": "pnpm@7.33.7",
   "author": "XPoet <i@xpoet.cn>",
   "license": "AGPL-3.0",
   "bugs": {


### PR DESCRIPTION
With lockfileVersion remaining unchanged, "pnpmv7" is the last version that supports "lockfileVersion: 5.4".

"lockfileVersion: 5.4" is in the "pnpm-lock.yaml " file